### PR TITLE
vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "eslint.enable": true
+  "eslint.enable": true,
+  "files.insertFinalNewline": true,
+  "editor.detectIndentation": false,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.rulers": [80]
 }


### PR DESCRIPTION
Added some vscode workspace settings:

- Tabs
  > Tabs will be inserted as 2 spaces regardless of other user settings
- EOF
  > Automatically insert new line at end of file
- 80 characters ruler
  > As the linter is going to alert when having more than 80 characters in a line, it will be nice to have the ruler set to 80