### PR TITLE
docs(homepage): show different subtitle on first install

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@
       <h1 class="title">
         <span class="kb-kibibit">kibibit</span>/tdd1t <span class="tag is-light">bot</span>
       </h1>
-      <h2 class="subtitle">
+      <h2 class="subtitle" id="kb-main-subtitle">
         Check that your tests cover you feature specifications
       </h2>
       <a class="button is-primary">Integrate Now</a>

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -4,3 +4,20 @@ setTimeout(() => {
 }, 1500);
 
 hljs.initHighlightingOnLoad();
+
+// TODO: We might change more elements based on first installation
+// like including more specific documentation
+if (getUrlVars().setup_action === 'install') {
+  $('#kb-main-subtitle').text('Thanks for integrating tdd1t');
+}
+
+function getUrlVars() {
+  var vars = {};
+
+  window.location.href
+    .replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
+      vars[key] = value;
+    });
+
+  return vars;
+}


### PR DESCRIPTION
this is just the first step.

We might change a few more things based on first installation (how to
use, etc.).
This will happen after we'll use a documentation theme instead of a static html file