### PR TITLE
ci(demo-deployments): deploy without an app id for PR deployments

### DIFF
--- a/deploy-pre-script.sh
+++ b/deploy-pre-script.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ! -z "$NOW_GITHUB_COMMIT_REF" ] && [ "$NOW_GITHUB_COMMIT_REF" != "master" ];
+then
+  echo 'Deployed as a demo GitHub application. reseting the APP_ID'
+  export APP_ID=""
+fi
+
+npm run start:bot

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "dev": "nodemon",
-    "start": "probot run ./index.js",
+    "start": "./deploy-pre-script.sh",
+    "start:bot": "probot run ./index.js",
     "lint": "eslint ./lib/*.js",
     "lint:fix": "eslint --fix ./lib/*.js",
     "commit": "git-cz",


### PR DESCRIPTION
this pre-run script should check the branch the deployment was done on and erease the APP_ID
environment variable to allow demoing it as a different temp app